### PR TITLE
fix: move to standard ignore implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@inquirer/prompts": "^6.0.1",
     "commander": "^13.1.0",
     "fflate": "^0.8.2",
+    "ignore": "^7.0.5",
     "node-forge": "^1.3.1",
     "zod": "^3.25.67"
   },

--- a/test/dxtignore.test.ts
+++ b/test/dxtignore.test.ts
@@ -293,7 +293,7 @@ coverage/`;
     });
 
     it("should handle negation with directory patterns", () => {
-      const additionalPatterns = ["tests/", "!tests/critical/"];
+      const additionalPatterns = ["tests/*", "!tests/critical/"];
 
       expect(shouldExclude("tests/unit/test.js", additionalPatterns)).toBe(
         true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,6 +2357,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
+ignore@^7.0.5:
+  version "7.0.5"
+  resolved "https://artifactory.infra.ant.dev:443/artifactory/api/npm/npm-all/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
+  integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
+
 import-fresh@^3.2.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"


### PR DESCRIPTION
Fixes #28

The `ignore` module is a pretty standard and well-used module for emulating `.gitignore` behavior. Our existing tests passed with the exception of one that wouldn't have worked with `gitignore` anyway so this caught a bug ish?

I'm also fairly sure that this fixes issues I was seeing on windows hosts with strange path matching behavior.