### PR TITLE
chore: correct tsconfig setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,12 +8,7 @@ export default {
     "^.+\\.ts$": [
       "ts-jest",
       {
-        tsconfig: {
-          module: "es2022",
-          esModuleInterop: true,
-          allowJs: true,
-          target: "es2020",
-        },
+        tsConfig: 'tsconfig.test.json'
       },
     ],
   },

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -3,7 +3,7 @@ import type {
   DxtUserConfigValues,
   Logger,
   McpServerConfig,
-} from "../types";
+} from "../types.js";
 
 /**
  * This file contains utility functions for handling DXT configuration,

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 
-import { DxtManifestSchema } from "../src/schemas";
+import { DxtManifestSchema } from "../src/schemas.js";
 
 describe("DxtManifestSchema", () => {
   it("should validate a valid manifest", () => {

--- a/test/sign.e2e.test.ts
+++ b/test/sign.e2e.test.ts
@@ -13,7 +13,7 @@ import * as fs from "fs";
 import forge from "node-forge";
 import * as path from "path";
 
-import { signDxtFile, unsignDxtFile, verifyDxtFile } from "../src/node/sign";
+import { signDxtFile, unsignDxtFile, verifyDxtFile } from "../src/node/sign.js";
 
 // Test directory
 const TEST_DIR = path.join(__dirname, "test-output");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     "target": "es2024",
     "lib": ["ES2023"],
 
-    "module": "es2022",
-    "moduleResolution": "node",
+    "module": "node18",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
 
     // Path settings
@@ -29,7 +29,7 @@
     "resolveJsonModule": true,
     "incremental": true,
     "preserveWatchOutput": true,
-    "types": ["node", "jest"]
+    "types": ["node"]
   },
   "include": ["src/**/*.ts", "src/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,8 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "module": "es2022",
-    "moduleResolution": "node"
+    "module": "node18",
+    "moduleResolution": "node16",
+    "types": ["node", "jest"],
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
- set module to `node18` to correct the output file (even `es2022` is same for now but some syntax or feature could be different) https://www.typescriptlang.org/tsconfig/#node16node18nodenext

- set moduleResolution to `node16` to difference cjs and esm import https://www.typescriptlang.org/tsconfig/#moduleResolution

- move "jest" to tsconfig.test.json and correct jest config