### PR TITLE
fix: Go back to zod/v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn run build:code && yarn run build:schema",
+    "build": "yarn run build:code",
     "build:code": "tsc",
     "build:schema": "node ./scripts/build-dxt-schema.js",
     "dev": "tsc --watch",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,4 +1,4 @@
-import * as z from "zod/v4";
+import * as z from "zod";
 
 export const McpServerConfigSchema = z.object({
   command: z.string(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type * as z from "zod/v4";
+import type * as z from "zod";
 
 import type {
   DxtManifestAuthorSchema,


### PR DESCRIPTION
We switched to Zod/v4, which is universally good - but also breaks everyone who started using this with Zod/v3, so we'll go back to v3 for now until we have a clean plan for going to v4.