### PR TITLE
fix: handle invalid values in arrays

### DIFF
--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -183,6 +183,10 @@ interface HasRequiredConfigMissingOptions {
   userConfig?: DxtUserConfigValues;
 }
 
+function isInvalidSingleValue(value: unknown): boolean {
+  return value === undefined || value === null || value === "";
+}
+
 /**
  * Check if an extension has missing required configuration
  * @param manifest The extension manifest
@@ -203,10 +207,9 @@ export function hasRequiredConfigMissing({
     if (configOption.required) {
       const value = config[key];
       if (
-        value === undefined ||
-        value === null ||
-        value === "" ||
-        (Array.isArray(value) && value.length === 0)
+        isInvalidSingleValue(value) ||
+        (Array.isArray(value) &&
+          (value.length === 0 || value.some(isInvalidSingleValue)))
       ) {
         return true;
       }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -408,6 +408,27 @@ describe("hasRequiredConfigMissing", () => {
     expect(result).toBe(true);
   });
 
+  it("should return true when required config is array with invalid values", () => {
+    const manifest: DxtManifest = {
+      ...baseManifest,
+      user_config: {
+        paths: {
+          type: "string",
+          title: "Paths",
+          description: "File paths",
+          required: true,
+          multiple: true,
+        },
+      },
+    };
+
+    const result = hasRequiredConfigMissing({
+      manifest,
+      userConfig: { paths: [""] },
+    });
+    expect(result).toBe(true);
+  });
+
   it("should return true when required config is empty array", () => {
     const manifest: DxtManifest = {
       ...baseManifest,


### PR DESCRIPTION
Values in arrays should be held to the same standard as root values.