### PR TITLE
fix: missing extension directory prefix in 'mcp_config' of python

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -315,9 +315,9 @@ The `mcp_config` object in the server configuration defines how the implementing
 ```json
 "mcp_config": {
   "command": "python",
-  "args": ["server/main.py"],
+  "args": ["${__dirname}/server/main.py"],
   "env": {
-    "PYTHONPATH": "server/lib"
+    "PYTHONPATH": "${__dirname}/server/lib"
   }
 }
 ```

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -110,7 +110,7 @@ export function createMcpConfig(
         command: "python",
         args: ["${__dirname}/" + entryPoint],
         env: {
-          PYTHONPATH: "server/lib",
+          PYTHONPATH: "${__dirname}/server/lib",
         },
       };
     case "binary":

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -142,7 +142,7 @@ describe("init functions", () => {
         command: "python",
         args: ["${__dirname}/server/main.py"],
         env: {
-          PYTHONPATH: "server/lib",
+          PYTHONPATH: "${__dirname}/server/lib",
         },
       });
     });
@@ -264,8 +264,8 @@ describe("init functions", () => {
           entryPoint: "server/main.py",
           mcp_config: {
             command: "python",
-            args: ["server/main.py"],
-            env: { PYTHONPATH: "server/lib" },
+            args: ["${__dirname}/server/main.py"],
+            env: { PYTHONPATH: "${__dirname}/server/lib" },
           },
         },
         [
@@ -325,8 +325,8 @@ describe("init functions", () => {
           entry_point: "server/main.py",
           mcp_config: {
             command: "python",
-            args: ["server/main.py"],
-            env: { PYTHONPATH: "server/lib" },
+            args: ["${__dirname}/server/main.py"],
+            env: { PYTHONPATH: "${__dirname}/server/lib" },
           },
         },
         tools: [


### PR DESCRIPTION
It seems that the extension directory prefix is missing in the `mcp_config` field for the `python` type.

I ran `dxt init` to generate a `manifest.json`, and then opened it in Claude Desktop after running `dxt pack`. Unfortunately, I encountered the following error:
```bash
ModuleNotFoundError: No module named 'fastmcp'
```
The generated `mcp_config` was:
```json
"mcp_config": {
  "command": "python",
  "args": [
    "${__dirname}/time_server.py"
  ],
  "env": {
    "PYTHONPATH": "server/lib"
  }
}
```
After some testing and cross-checking with [python example](https://github.com/anthropics/dxt/blob/4fbb2aed2cdcfa1295ae6bffea0e5dbe5076ea51/examples/file-manager-python/manifest.json#L25), I found that the correct configuration should be:
```json
"mcp_config": {
  "command": "python",
  "args": [
    "${__dirname}/time_server.py"
  ],
  "env": {
    "PYTHONPATH": "${__dirname}/server/lib" // modify here
  }
}
```
Let me know if this is something you'd like to address—I’d be happy to help improve it.
